### PR TITLE
The latest working playbook : 20-07-2021

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -1,77 +1,119 @@
 ---
 - hosts: all
   vars:
-    docker_network: mynet
+    docker_network: bridge  
+#    host_network: host
 
   tasks:
-  - name: Create Prometheus User
-    user:
-      name: prometheus
-      shell: /bin/false
-      system: true
-    tags: user
+#  - name: Create Prometheus User
+#    user:
+#      name: prometheus
+#      shell: /bin/false
+#      system: true
+#    tags: user
 
   - name: Create Prometheus Directory
     file:
       path: "{{ item }}"
       state: directory
-      mode: 0775
+      mode: '0775'
       owner: santosh
+      group: santosh
     with_items:
       - /etc/prometheus/conf
       - /etc/prometheus/conf/rrules
       - /etc/prometheus/conf/alerts
     tags: directory
-
-  - name: Create prometheus.yml
-    file:
-      path: /etc/prometheus/prometheus.yml
-      state: touch
-      mode: 0775
-      owner: santosh
-    tags: directory
     become: true
 
-  - name: Place configuration files
+#  - name: Create prometheus.yml
+#    file:
+#      path: /etc/prometheus/prometheus.yml
+#      state: touch
+#      mode: 0775
+#      owner: santosh
+#    tags: directory
+#    become: true
+
+# The Source location 'src' of this file has to be added
+# as per where you place the file in your environment
+  - name: Place prometheus server config. files
     copy:
       src: /home/santosh/workspace/devops/workplace/ansible/prom-core/configs/prometheus.yml
       dest: /etc/prometheus/prometheus.yml
-      mode: 0775
+      mode: '0775'
+      owner: santosh
+      group: santosh
+    tags: file
+    become: true
+
+  - name: Place alerts config. file
+    copy:
+      src: /home/santosh/workspace/devops/workplace/ansible/prom-core/configs/alert.rules.yml
+      dest: /etc/prometheus/conf/alerts/
+      mode: '0775'
       owner: santosh
     tags: file
-
 
   - name: Create Data Directory for Prometheus
     file:
       path: /var/lib/prometheus
       state: directory
-      mode: 0775
+      mode: '0775'
       owner: santosh
+      group: santosh
+    become: true
     tags: directory
+
+  - name: Recursice change of permission of this directory
+    file:
+      path: /var/lib/prometheus
+      state: directory
+      recurse: yes
+      owner: santosh
+      group: santosh
+    become: true
 
   - name: Start Prometheus container
     docker_container:
       name: prometheus-core
       image: prom/prometheus
-#      networks_cli_compatible: no
-#      network_mode: mynet
-#      networks:
-#        - name: "{{ docker_network }}"
-#          ipv4_address:
       user: 1000
       ports:
-        - "9090:9090"
-      log_options:
-         max-size: "100m"
+#        - "9090:9090"
+      network_mode: host 
+#      log_options:
+#         max-size: "100m"
       volumes:
-        - /etc/prometheus/prometheus.yml:/data/prometheus/prometheus.yml
+        - /etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
         - /var/lib/prometheus:/data/prometheus
-        - /data/prometheus:/prom/prometheus
-      hostname: "prom-core"
+#        - /data/prometheus:/prom/prometheus
+#      hostname: "prom-core"
       command: [ "--config.file=/etc/prometheus/prometheus.yml",
                  "--storage.tsdb.retention=30d",
                  "--storage.tsdb.path=/data/prometheus"]
 
+  - name: Start Node-Exporter Container
+    docker_container:
+      name: node-exporter
+      image: prom/node-exporter
+      user: 1000:1000
+#      ports:
+#        - 9100:9100
+      volumes:
+        - /:/hostfs
+      network_mode: host #could be changed to bridge but 'host' wont let port bindings to container
+#      networks: #temperory
+#        - name: "{{ docker_network }}" #temperory
+#      hostname: "node-exporter"
+      command: ["--path.rootfs=/hostfs"]
+    tags: node
+
+
+#  - name: Start Alert Manager COntainer
+#    docker_container:
+#    name: alert-manager
+#    image:
 
 
 #  - name: Create Prometheus User

--- a/prom-core/configs/prometheus.yml
+++ b/prom-core/configs/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval:     15s # By default, scrape targets every 15 seconds.
   external_labels:
     monitor: 'localhost'
-  query_log_file: /prometheus/query.log
+#  query_log_file: /prometheus/query.log
 
 rule_files:
   - '/etc/prometheus/alerts/alert.rules.yml'
@@ -10,11 +10,13 @@ rule_files:
 scrape_configs:
   - job_name: 'prometheus'
     scrape_interval: 5s
+    follow_redirects: false
     static_configs:
       - targets: ['localhost:9090']
 
   - job_name: 'node_exporter'
     scrape_interval: 10s
+    follow_redirects: false
     static_configs:
       - targets: ['localhost:9100']
 


### PR DESCRIPTION
The current playbook when deployed almost quite directly should be able to create Prometheus and 1 local-host Node-Exporter setup as containers.
In case the prom-server initiation fails, please check permissions of the created directories.
All containers have network-mode as host and are didn't needed port mapping.
These containers follow default bridge network and hence communicate with each other without any issue.

More amendments coming soon ;)